### PR TITLE
[YouTube] Improve download speed

### DIFF
--- a/app/src/main/java/org/schabi/newpipelegacy/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipelegacy/fragments/detail/VideoDetailFragment.java
@@ -1086,7 +1086,7 @@ public final class VideoDetailFragment
             player.toggleFullscreen();
         }
 
-        if (!useExternalAudioPlayer) { && android.os.Build.VERSION.SDK_INT >= 16) {
+        if (!useExternalAudioPlayer) {
             openNormalBackgroundPlayer(append);
         } else {
             startOnExternalPlayer(activity, currentInfo, audioStream);

--- a/app/src/main/java/org/schabi/newpipelegacy/player/resolver/AudioPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipelegacy/player/resolver/AudioPlaybackResolver.java
@@ -9,7 +9,9 @@ import com.google.android.exoplayer2.source.MediaSource;
 
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.stream.AudioStream;
+import org.schabi.newpipe.extractor.stream.Stream;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
+import org.schabi.newpipe.extractor.stream.VideoStream;
 import org.schabi.newpipelegacy.player.helper.PlayerDataSource;
 import org.schabi.newpipelegacy.player.helper.PlayerHelper;
 import org.schabi.newpipelegacy.util.ListHelper;

--- a/app/src/main/java/org/schabi/newpipelegacy/util/PermissionHelper.java
+++ b/app/src/main/java/org/schabi/newpipelegacy/util/PermissionHelper.java
@@ -26,7 +26,6 @@ public final class PermissionHelper {
     private PermissionHelper() { }
 
     public static boolean checkStoragePermissions(final Activity activity, final int requestCode) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             if (!checkReadStoragePermissions(activity, requestCode)) {
                 return false;
             }

--- a/app/src/main/java/us/shandian/giga/get/DownloadInitializer.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadInitializer.java
@@ -54,12 +54,12 @@ public class DownloadInitializer extends Thread {
                     long lowestSize = Long.MAX_VALUE;
 
                     for (int i = 0; i < mMission.urls.length && mMission.running; i++) {
-                        mConn = mMission.openConnection(mMission.urls[i], true, -1, -1);
+                        mConn = mMission.openConnection(mMission.urls[i], true, 0, 0);
                         mMission.establishConnection(mId, mConn);
                         dispose();
 
                         if (Thread.interrupted()) return;
-                        long length = Utility.getContentLength(mConn);
+                        long length = Utility.getTotalContentLength(mConn);
 
                         if (i == 0) {
                             httpCode = mConn.getResponseCode();
@@ -84,14 +84,14 @@ public class DownloadInitializer extends Thread {
                     }
                 } else {
                     // ask for the current resource length
-                    mConn = mMission.openConnection(true, -1, -1);
+                    mConn = mMission.openConnection(true, 0, 0);
                     mMission.establishConnection(mId, mConn);
                     dispose();
 
                     if (!mMission.running || Thread.interrupted()) return;
 
                     httpCode = mConn.getResponseCode();
-                    mMission.length = Utility.getContentLength(mConn);
+                    mMission.length = Utility.getTotalContentLength(mConn);
                 }
 
                 if (mMission.length == 0 || httpCode == 204) {

--- a/app/src/main/java/us/shandian/giga/util/Utility.java
+++ b/app/src/main/java/us/shandian/giga/util/Utility.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Locale;
 
 import us.shandian.giga.io.StoredFileHelper;
+import us.shandian.giga.get.DownloadMission;
 
 public class Utility {
 
@@ -264,6 +265,28 @@ public class Utility {
 
         try {
             return Long.parseLong(connection.getHeaderField("Content-Length"));
+        } catch (Exception err) {
+            // nothing to do
+        }
+
+        return -1;
+    }
+
+    /**
+     * Get the content length of the entire file even if the HTTP response is partial
+     * (response code 206).
+     * @param connection http connection
+     * @return content length
+     */
+    public static long getTotalContentLength(final HttpURLConnection connection) {
+        try {
+            if (connection.getResponseCode() == 206) {
+                final String rangeStr = connection.getHeaderField("Content-Range");
+                final String bytesStr = rangeStr.split("/", 2)[1];
+                return Long.parseLong(bytesStr);
+            } else {
+                return getContentLength(connection);
+            }
         } catch (Exception err) {
             // nothing to do
         }


### PR DESCRIPTION
Author: Theta-Dev

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

Description of the changes in your PR

    YouTube throttles all requests to their streams if they dont have either a Range header or a &range=n-m URL parameter
    YouTube's throttling is triggered by HEAD requests, too. Since the downloader uses HEAD requests to determine the file size, the subsequent GET requests will be throttled, too
    I modified the downloader to use HEAD requests with a range header to determine the file size. YouTube will return a Content-Range header for these requests, e.g. (bytes 0-0/4530953) which can be parsed to get the total size.
    The improvement is most noticeable on small audio files. Songs download almost instantly now.
    Larger audio files still get throttled at the end of a download, I am not sure how to fix this.


#### Fixes the following issue(s)
- Fixes #
Fixes [YouTube] Downloads frequently slow down

#### APK testing 
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).